### PR TITLE
 Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -33,6 +33,8 @@ jobs:
                   name: Ballerina Internal Log
                   path: graphql-ballerina/ballerina-internal.log
                   if-no-files-found: ignore
+            - name: Generate Codecov Report
+              uses: codecov/codecov-action@v1
             - name: Archive Code Coverage JSON
               uses: actions/upload-artifact@v2
               with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,6 +23,8 @@ jobs:
                   name: Ballerina Internal Log
                   path: graphql-ballerina/ballerina-internal.log
                   if-no-files-found: ignore
+            - name: Generate Codecov Report
+              uses: codecov/codecov-action@v1
             - name: Archive Code Coverage JSON
               uses: actions/upload-artifact@v2
               with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: no
+
+fixes:
+  - "ballerina/websocket/*/::websocket-ballerina/"
+
+ignore:
+  - "**/tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ codecov:
   require_ci_to_pass: no
 
 fixes:
-  - "ballerina/rabbitmq/*/::rabbitmq-ballerina/"
+  - "ballerinax/rabbitmq/*/::rabbitmq-ballerina/"
 
 ignore:
   - "**/tests"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ codecov:
   require_ci_to_pass: no
 
 fixes:
-  - "ballerina/websocket/*/::websocket-ballerina/"
+  - "ballerina/rabbitmq/*/::rabbitmq-ballerina/"
 
 ignore:
   - "**/tests"


### PR DESCRIPTION
## Purpose
> Introducing Codecov code coverage report publishing to the rabbitmq repository

## Goals
> Publishing the testerina generated code coverage xml to Codecov triggered via GitHub action of PR.

## Approach
>   A new job is inserted to Pull request and Build GitHub actions that publishes the XML report to Codecov.
    These jobs trigger on push or pull request and CodeCov generates a descriptive code coverage report.
    Codecov also adds comments to any PR made based on the code coverage changes between commits