### PR TITLE
Update SecureSocket record

### DIFF
--- a/rabbitmq-ballerina/rabbitmq_commons.bal
+++ b/rabbitmq-ballerina/rabbitmq_commons.bal
@@ -110,16 +110,25 @@ public type QosSettings record {|
 
 # Configurations for facilitating secure connections.
 #
-# + trustStore - Configurations associated with the TrustStore
-# + keyStore - Configurations associated with the KeyStore
-# + protocol - TLS protocol
-# + verifyHostname - True if hostname verification should be enabled
+# + cert - Configurations associated with `crypto:TrustStore`
+# + key - Configurations associated with `crypto:KeyStore`
+# + protocol - SSL/TLS protocol related options
+# + verifyHostName - Enable/disable host name verification
 public type SecureSocket record {|
-    crypto:TrustStore trustStore?;
-    crypto:KeyStore keyStore?;
-    string protocol = "TLS";
-    boolean verifyHostname = true;
+    crypto:TrustStore cert;
+    crypto:KeyStore key?;
+    record {|
+        Protocol name;
+    |} protocol?;
+    boolean verifyHostName = true;
 |};
+
+# Represents protocol options.
+public enum Protocol {
+   SSL,
+   TLS,
+   DTLS
+}
 
 # Configurations related to authentication.
 #

--- a/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/RabbitMQConstants.java
+++ b/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/RabbitMQConstants.java
@@ -83,10 +83,11 @@ public class RabbitMQConstants {
             "shutdownTimeout");
     public static final BString RABBITMQ_CONNECTION_HEARTBEAT = StringUtils.fromString("heartbeat");
     public static final BString RABBITMQ_CONNECTION_SECURE_SOCKET = StringUtils.fromString("secureSocket");
-    public static final BString RABBITMQ_CONNECTION_KEYSTORE = StringUtils.fromString("keyStore");
-    public static final BString RABBITMQ_CONNECTION_TRUSTORE = StringUtils.fromString("trustStore");
-    public static final BString RABBITMQ_CONNECTION_VERIFY_HOST = StringUtils.fromString("verifyHostname");
-    public static final BString RABBITMQ_CONNECTION_SECURE_SOCKET_PROTOCOL = StringUtils.fromString("protocol");
+    public static final BString CONNECTION_KEYSTORE = StringUtils.fromString("key");
+    public static final BString CONNECTION_TRUSTORE = StringUtils.fromString("cert");
+    public static final BString CONNECTION_VERIFY_HOST = StringUtils.fromString("verifyHostName");
+    public static final BString CONNECTION_PROTOCOL = StringUtils.fromString("protocol");
+    public static final BString CONNECTION_PROTOCOL_NAME = StringUtils.fromString("name");
     public static final String KEY_STORE_TYPE = "PKCS12";
     public static final BString KEY_STORE_PASS = StringUtils.fromString("password");
     public static final BString KEY_STORE_PATH = StringUtils.fromString("path");

--- a/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
+++ b/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
@@ -190,7 +190,7 @@ public class ConnectionUtils {
                 sslContext = SSLContext.getDefault();
             }
             sslContext.init(keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
-                            trustManagerFactory.getTrustManagers(), null);
+                            trustManagerFactory.getTrustManagers(), new SecureRandom());
             return sslContext;
         } catch (FileNotFoundException exception) {
             throw RabbitMQUtils.returnErrorValue(RabbitMQConstants.CREATE_SECURE_CONNECTION_ERROR +

--- a/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
+++ b/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
@@ -179,22 +179,16 @@ public class ConnectionUtils {
 
 
             // protocol
-            String protocol = null;
+            SSLContext sslContext;
             if (secureSocket.containsKey(RabbitMQConstants.CONNECTION_PROTOCOL)) {
                 @SuppressWarnings("unchecked")
                 BMap<BString, Object> protocolRecord =
                         (BMap<BString, Object>) secureSocket.getMapValue(RabbitMQConstants.CONNECTION_PROTOCOL);
-                protocol = protocolRecord.getStringValue(RabbitMQConstants.CONNECTION_PROTOCOL_NAME).getValue();
-            }
-
-            // SSL Context
-            SSLContext sslContext;
-            if (protocol == null) {
-                sslContext = SSLContext.getDefault();
-            } else {
+                String protocol = protocolRecord.getStringValue(RabbitMQConstants.CONNECTION_PROTOCOL_NAME).getValue();
                 sslContext = SSLContext.getInstance(protocol);
+            } else {
+                sslContext = SSLContext.getDefault();
             }
-
             sslContext.init(keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
                             trustManagerFactory.getTrustManagers(), null);
             return sslContext;

--- a/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
+++ b/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
@@ -72,7 +72,7 @@ public class ConnectionUtils {
             if (secureSocket != null) {
                 SSLContext sslContext = getSSLContext(secureSocket);
                 connectionFactory.useSslProtocol(sslContext);
-                if (secureSocket.getBooleanValue(RabbitMQConstants.RABBITMQ_CONNECTION_VERIFY_HOST)) {
+                if (secureSocket.getBooleanValue(RabbitMQConstants.CONNECTION_VERIFY_HOST)) {
                     connectionFactory.enableHostnameVerification();
                 }
                 LOGGER.info("TLS enabled for the connection.");
@@ -131,34 +131,39 @@ public class ConnectionUtils {
         return (valueInSeconds.multiply(MILLISECOND_MULTIPLIER)).intValue();
     }
 
-    private static SSLContext getSSLContext(BMap secureSocket) {
+    private static SSLContext getSSLContext(BMap<BString, Object> secureSocket) {
         try {
-            BMap cryptoKeyStore = secureSocket.getMapValue(RabbitMQConstants.RABBITMQ_CONNECTION_KEYSTORE);
-            BMap cryptoTrustStore = secureSocket.getMapValue(RabbitMQConstants.RABBITMQ_CONNECTION_TRUSTORE);
-            char[] keyPassphrase = cryptoKeyStore.getStringValue(RabbitMQConstants.KEY_STORE_PASS).getValue()
-                    .toCharArray();
-            String keyFilePath = cryptoKeyStore.getStringValue(RabbitMQConstants.KEY_STORE_PATH).getValue();
+            // keystore
+            KeyManagerFactory keyManagerFactory = null;
+            if (secureSocket.containsKey(RabbitMQConstants.CONNECTION_KEYSTORE)) {
+                @SuppressWarnings("unchecked")
+                BMap<BString, Object> cryptoKeyStore =
+                        (BMap<BString, Object>) secureSocket.getMapValue(RabbitMQConstants.CONNECTION_KEYSTORE);
+                char[] keyPassphrase = cryptoKeyStore.getStringValue(RabbitMQConstants.KEY_STORE_PASS).getValue()
+                        .toCharArray();
+                String keyFilePath = cryptoKeyStore.getStringValue(RabbitMQConstants.KEY_STORE_PATH).getValue();
+                KeyStore keyStore = KeyStore.getInstance(RabbitMQConstants.KEY_STORE_TYPE);
+                if (keyFilePath != null) {
+                    try (FileInputStream keyFileInputStream = new FileInputStream(keyFilePath)) {
+                        keyStore.load(keyFileInputStream, keyPassphrase);
+                    }
+                } else {
+                    RabbitMQMetricsUtil.reportError(RabbitMQObservabilityConstants.ERROR_TYPE_CONNECTION);
+                    throw RabbitMQUtils.returnErrorValue(RabbitMQConstants.CREATE_SECURE_CONNECTION_ERROR +
+                                                                 "Path for the keystore is not found.");
+                }
+                keyManagerFactory =
+                        KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                keyManagerFactory.init(keyStore, keyPassphrase);
+            }
+
+            // truststore
+            @SuppressWarnings("unchecked")
+            BMap<BString, Object> cryptoTrustStore =
+                    (BMap<BString, Object>) secureSocket.getMapValue(RabbitMQConstants.CONNECTION_TRUSTORE);
             char[] trustPassphrase = cryptoTrustStore.getStringValue(RabbitMQConstants.KEY_STORE_PASS).getValue()
                     .toCharArray();
             String trustFilePath = cryptoTrustStore.getStringValue(RabbitMQConstants.KEY_STORE_PATH).getValue();
-            String protocol =
-                    secureSocket.getStringValue(RabbitMQConstants.RABBITMQ_CONNECTION_SECURE_SOCKET_PROTOCOL)
-                            .getValue();
-
-            KeyStore keyStore = KeyStore.getInstance(RabbitMQConstants.KEY_STORE_TYPE);
-            if (keyFilePath != null) {
-                try (FileInputStream keyFileInputStream = new FileInputStream(keyFilePath)) {
-                    keyStore.load(keyFileInputStream, keyPassphrase);
-                }
-            } else {
-                RabbitMQMetricsUtil.reportError(RabbitMQObservabilityConstants.ERROR_TYPE_CONNECTION);
-                throw RabbitMQUtils.returnErrorValue(RabbitMQConstants.CREATE_SECURE_CONNECTION_ERROR +
-                                                             "Path for the keystore is not found.");
-            }
-            KeyManagerFactory keyManagerFactory =
-                    KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            keyManagerFactory.init(keyStore, keyPassphrase);
-
             KeyStore trustStore = KeyStore.getInstance(RabbitMQConstants.KEY_STORE_TYPE);
             if (trustFilePath != null) {
                 try (FileInputStream trustFileInputStream = new FileInputStream(trustFilePath)) {
@@ -172,8 +177,26 @@ public class ConnectionUtils {
                     TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             trustManagerFactory.init(trustStore);
 
-            SSLContext sslContext = SSLContext.getInstance(protocol);
-            sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
+
+            // protocol
+            String protocol = null;
+            if (secureSocket.containsKey(RabbitMQConstants.CONNECTION_PROTOCOL)) {
+                @SuppressWarnings("unchecked")
+                BMap<BString, Object> protocolRecord =
+                        (BMap<BString, Object>) secureSocket.getMapValue(RabbitMQConstants.CONNECTION_PROTOCOL);
+                protocol = protocolRecord.getStringValue(RabbitMQConstants.CONNECTION_PROTOCOL_NAME).getValue();
+            }
+
+            // SSL Context
+            SSLContext sslContext;
+            if (protocol == null) {
+                sslContext = SSLContext.getDefault();
+            } else {
+                sslContext = SSLContext.getInstance(protocol);
+            }
+
+            sslContext.init(keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null,
+                            trustManagerFactory.getTrustManagers(), null);
             return sslContext;
         } catch (FileNotFoundException exception) {
             throw RabbitMQUtils.returnErrorValue(RabbitMQConstants.CREATE_SECURE_CONNECTION_ERROR +

--- a/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
+++ b/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
@@ -39,6 +39,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.concurrent.TimeoutException;


### PR DESCRIPTION
## Purpose
This updates the `SecureSocket` record to be used in client configurations. 
Updated record definition:
```ballerina
# Configurations related to facilitating secure communication with a remote HTTP endpoint.
#
# + cert - Configurations associated with `crypto:TrustStore`
# + key - Configurations associated with `crypto:KeyStore`
# + protocol - SSL/TLS protocol related options
# + verifyHostName - Enable/disable host name verification
public type SecureSocket record {|
    crypto:TrustStore cert;
    crypto:KeyStore key?;
    record {|
        Protocol name;
    |} protocol?;
    boolean verifyHostName = true;
|};

public enum Protocol {
   SSL,
   TLS,
   DTLS
}
```

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1074