### PR TITLE
RabbitMQ package updates for Swan Lake alpha4

### DIFF
--- a/rabbitmq-ballerina/Package.md
+++ b/rabbitmq-ballerina/Package.md
@@ -16,7 +16,7 @@ Key sections include:
 The following code connects to a RabbitMQ node with default host and port: 
 
 ```ballerina
-   rabbitmq:Client newClient = new;
+   rabbitmq:Client newClient = check new(rabbitmq:DEFAULT_HOST, rabbitmq:DEFAULT_PORT);
 ```
 
 The `rabbitmq:Client` can now be used to send and receive messages as described in the subsequent sections. 
@@ -37,10 +37,8 @@ Client applications work with exchanges and queues, which are the high-level bui
    rabbitmq:Error? exchangeResult = newClient->exchangeDeclare("MyExchange", 
                                                                 rabbitmq:DIRECT_EXCHANGE);
    
-   string|rabbitmq:Error? queueResult = newClient->queueDeclare("MyQueue");
-   if (queueResult is string) {
-        rabbitmq:Error? bindResult = newClient->queueBind("MyQueue", "MyExchange", "routing-key");
-   }
+   rabbitmq:Error? queueResult = newClient->queueDeclare("MyQueue");
+   rabbitmq:Error? bindResult = newClient->queueBind("MyQueue", "MyExchange", "routing-key");
 ```
 
 This sample code will declare,
@@ -53,10 +51,10 @@ Next, the above function is called to bind the queue to the exchange with the gi
    rabbitmq:Error? exchangeResult = newClient->exchangeDeclare("MyExchange",
                                                         rabbitmq:DIRECT_EXCHANGE);
    
-   string|rabbitmq:Error? queueResult = newClient->queueDeclare("MyQueue", 
-                                                { durable: true,
-                                                  exclusive: false,
-                                                  autoDelete: false });
+   rabbitmq:Error? queueResult = newClient->queueDeclare("MyQueue", 
+                                                        { durable: true,
+                                                          exclusive: false,
+                                                          autoDelete: false });
 
    rabbitmq:Error? bindResult = newClient->queueBind("MyQueue", "MyExchange", "routing-key");
 ```
@@ -105,14 +103,14 @@ The most efficient way to receive messages is to set up a subscription using a B
 Multiple consumer services can be bound to one Ballerina RabbitMQ `rabbitmq:Listener`. The queue to which the service is listening is configured in the `rabbitmq:ServiceConfig` annotation of the service. 
 
 ```ballerina
-listener rabbitmq:Listener channelListener= new;
+listener rabbitmq:Listener channelListener= new(rabbitmq:DEFAULT_HOST, rabbitmq:DEFAULT_PORT);
 
 @rabbitmq:ServiceConfig {
     queueName: "MyQueue"
 }
-service rabbitmqConsumer on channelListener {
+
+service rabbitmq:Service on channelListener {
     remote function onMessage(rabbitmq:Message message) {
-        // Do something with the message here 
     }
 }
 ```

--- a/rabbitmq-ballerina/client.bal
+++ b/rabbitmq-ballerina/client.bal
@@ -25,9 +25,11 @@ public client class Client {
 
     # Initializes a `rabbitmq:Client` object.
     #
+    # + host - The host used for establishing the connection
+    # + port - The port used for establishing the connection
     # + connectionData - A connection configuration
-    public isolated function init(ConnectionConfiguration connectionData = {}) returns Error? {
-        handle|Error channelResult = createChannel(connectionData, self);
+    public isolated function init(string host, int port, *ConnectionConfiguration connectionData) returns Error? {
+        handle|Error channelResult = createChannel(host, port, connectionData, self);
         if (channelResult is handle) {
             self.amqpChannel = channelResult;
             return;
@@ -213,8 +215,8 @@ public client class Client {
     }
 }
 
-isolated function createChannel(ConnectionConfiguration config, Client channelObj) returns handle|Error =
-@java:Method {
+isolated function createChannel(string host, int port, *ConnectionConfiguration config, Client channelObj)
+returns handle|Error = @java:Method {
     'class: "org.ballerinalang.messaging.rabbitmq.util.ChannelUtils"
 } external;
 

--- a/rabbitmq-ballerina/listener.bal
+++ b/rabbitmq-ballerina/listener.bal
@@ -26,11 +26,13 @@ public class Listener {
     # Initializes a Listener object with the given connection configuration. Sets the global QoS settings,
     # which will be applied to the entire `rabbitmq:Listener`.
     #
+    # + host - The host used for establishing the connection
+    # + port - The port used for establishing the connection
     # + connectionData - The connection configuration
     # + qosSettings - Consumer prefetch settings
-    public isolated function init(ConnectionConfiguration connectionData = {},
+    public isolated function init(string host, int port, *ConnectionConfiguration connectionData,
                                      QosSettings? qosSettings = ()) returns Error? {
-        Error? initResult = externInit(self, connectionData);
+        Error? initResult = externInit(host, port, self, connectionData);
         if (initResult is Error) {
             return initResult;
         } else {
@@ -94,8 +96,8 @@ public type RabbitMQServiceConfig record {|
 # The annotation, which is used to configure the subscription.
 public annotation RabbitMQServiceConfig ServiceConfig on service, class;
 
-isolated function externInit(Listener lis, ConnectionConfiguration connectionData) returns Error? =
-@java:Method {
+isolated function externInit(string host, int port, Listener lis, *ConnectionConfiguration connectionData)
+returns Error? = @java:Method {
     name: "init",
     'class: "org.ballerinalang.messaging.rabbitmq.util.ListenerUtils"
 } external;

--- a/rabbitmq-ballerina/rabbitmq_commons.bal
+++ b/rabbitmq-ballerina/rabbitmq_commons.bal
@@ -19,6 +19,12 @@ import ballerina/jballerina.java;
 
 final handle JAVA_NULL = java:createNull();
 
+# Constant for the default host
+public const DEFAULT_HOST = "localhost";
+
+# Constant for the default port
+public const DEFAULT_PORT = 5672;
+
 # Types of exchanges supported by the Ballerina RabbitMQ Connector.
 public type ExchangeType "direct"|"fanout"|"topic"|"headers";
 
@@ -70,8 +76,6 @@ public type ExchangeConfig record {|
 
 # Configurations used to create a `rabbitmq:Connection`.
 #
-# + host - The host used for establishing the connection
-# + port - The port used for establishing the connection
 # + username - The username used for establishing the connection
 # + password - The password used for establishing the connection
 # + connectionTimeout - Connection TCP establishment timeout in seconds and zero for infinite
@@ -82,8 +86,6 @@ public type ExchangeConfig record {|
 # + secureSocket - Configurations for facilitating secure connections
 # + auth - Configurations releated to authentication
 public type ConnectionConfiguration record {|
-    string host = "localhost";
-    int port = 5672;
     string username?;
     string password?;
     decimal connectionTimeout?;

--- a/rabbitmq-ballerina/tests/unit_tests.bal
+++ b/rabbitmq-ballerina/tests/unit_tests.bal
@@ -33,7 +33,7 @@ string REPLYTO = "replyHere";
 @test:BeforeSuite
 function setup() {
     log:printInfo("Creating a ballerina RabbitMQ channel.");
-    Client newClient = checkpanic new;
+    Client newClient = checkpanic new(DEFAULT_HOST, DEFAULT_PORT);
     rabbitmqChannel = newClient;
     Client? clientObj = rabbitmqChannel;
     if (clientObj is Client) {
@@ -43,7 +43,7 @@ function setup() {
         string? ackQueue = checkpanic clientObj->queueDeclare(ACK_QUEUE);
         string? replyQueue = checkpanic clientObj->queueDeclare(REPLYTO);
     }
-    Listener lis = checkpanic new;
+    Listener lis = checkpanic new(DEFAULT_HOST, DEFAULT_PORT);
     rabbitmqListener = lis;
 }
 
@@ -56,7 +56,7 @@ public function testClient() {
     if (con is Client) {
         flag = true;
     }
-    Client newClient = checkpanic new;
+    Client newClient = checkpanic new(DEFAULT_HOST, DEFAULT_PORT);
     checkpanic newClient.close();
     test:assertTrue(flag, msg = "RabbitMQ Connection creation failed.");
 }

--- a/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ChannelUtils.java
+++ b/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ChannelUtils.java
@@ -52,8 +52,9 @@ import java.util.concurrent.TimeoutException;
  * @since 0.995.0
  */
 public class ChannelUtils {
-    public static Object createChannel(BMap<BString, Object> connectionConfig, BObject channelObj) {
-        Connection connection = ConnectionUtils.createConnection(connectionConfig);
+    public static Object createChannel(BString host, long port, BMap<BString, Object> connectionConfig,
+                                       BObject channelObj) {
+        Connection connection = ConnectionUtils.createConnection(host, port, connectionConfig);
         try {
             Channel channel = connection.createChannel();
             RabbitMQMetricsUtil.reportNewChannel(channel);

--- a/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
+++ b/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ConnectionUtils.java
@@ -63,7 +63,7 @@ public class ConnectionUtils {
      * @param connectionConfig Parameters used to initialize the connection.
      * @return RabbitMQ Connection object.
      */
-    public static Connection createConnection(BMap<BString, Object> connectionConfig) {
+    public static Connection createConnection(BString host, long port, BMap<BString, Object> connectionConfig) {
         try {
             ConnectionFactory connectionFactory = new ConnectionFactory();
 
@@ -79,11 +79,10 @@ public class ConnectionUtils {
                 LOGGER.info("TLS enabled for the connection.");
             }
 
-            String host = connectionConfig.getStringValue(RabbitMQConstants.RABBITMQ_CONNECTION_HOST).getValue();
-            connectionFactory.setHost(host);
+            connectionFactory.setHost(host.getValue());
 
-            int port = Math.toIntExact(connectionConfig.getIntValue(RabbitMQConstants.RABBITMQ_CONNECTION_PORT));
-            connectionFactory.setPort(port);
+            int portInt = Math.toIntExact(port);
+            connectionFactory.setPort(portInt);
 
             Object username = connectionConfig.get(RabbitMQConstants.RABBITMQ_CONNECTION_USER);
             if (username != null) {

--- a/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ListenerUtils.java
+++ b/rabbitmq-native/src/main/java/org/ballerinalang/messaging/rabbitmq/util/ListenerUtils.java
@@ -60,8 +60,9 @@ public class ListenerUtils {
     private static final BString IO_ERROR_MSG = StringUtils
             .fromString("An I/O error occurred while setting the global quality of service settings for the listener");
 
-    public static Object init(BObject listenerBObject, BMap<BString, Object> connectionConfig) {
-        Connection connection = ConnectionUtils.createConnection(connectionConfig);
+    public static Object init(BString host, long port, BObject listenerBObject,
+                              BMap<BString, Object> connectionConfig) {
+        Connection connection = ConnectionUtils.createConnection(host, port, connectionConfig);
         Channel channel;
         try {
             channel = connection.createChannel();


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/1178

## Changes:
1. Client and listener init change **[Breaking]** 
```ballerina
// old syntax
rabbitmq:Client newClient = check new;
rabbitmq:Client newClient = check new({host: "localhost", port: 5672})

// new syntax - host, port is not defaultable, it is mandatory
rabbitmq:Client newClient = check new(rabbitmq:DEFAULT_HOST, rabbitmq:DEFAULT_PORT);

// similar in both client and listener. ConnectionConfiguration is changed to an included record parameter
// in both can pass remaining config values as named args
```