### PR TITLE
Update flag for coverage format

### DIFF
--- a/rabbitmq-ballerina/build.gradle
+++ b/rabbitmq-ballerina/build.gradle
@@ -65,7 +65,7 @@ ballerina{
     packageOrganization = packageOrg
     module = packageName
     langVersion = ballerinaLangVersion
-    testCoverageParam = "--code-coverage --jacoco-xml --includes=org.ballerinalang.messaging.rabbitmq.*:ballerinax.rabbitmq.*"
+    testCoverageParam = "--code-coverage --coverage-format=xml --includes=org.ballerinalang.messaging.rabbitmq.*:ballerinax.rabbitmq.*"
 }
 
 configurations {


### PR DESCRIPTION
## Purpose
Update flag for coverage format from '--jacoco-xml' to '--coverage-format=xml'

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests