### PR TITLE
Mark close and abort functions as remote

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@ This file contains all the notable changes done to the Ballerina RabbitMQ packag
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Mark close and abort functions in RabbitMQ client as remote 
+
 ## [1.1.0-alpha9] - 2021-04-22
 
 ### Added

--- a/rabbitmq-ballerina/client.bal
+++ b/rabbitmq-ballerina/client.bal
@@ -190,7 +190,7 @@ public isolated client class Client {
 
     # Closes the `rabbitmq:Client`.
     # ```ballerina
-    # check rabbitmqClient.close();
+    # check rabbitmqClient->close();
     # ```
     #
     # + closeCode - The close code (for information, go to the [Reply Codes]
@@ -205,7 +205,7 @@ public isolated client class Client {
     # Aborts the RabbitMQ `rabbitmq:Client`. Forces the `rabbitmq:Client` to close and waits for all the close operations
     # to complete. Any encountered exceptions in the close operations are discarded silently.
     # ```ballerina
-    # check rabbitmqClient.abort(320, "Client Aborted");
+    # check rabbitmqClient->abort(320, "Client Aborted");
     # ```
     #
     # + closeCode - The close code (for information, go to the [Reply Codes]

--- a/rabbitmq-ballerina/client.bal
+++ b/rabbitmq-ballerina/client.bal
@@ -197,7 +197,7 @@ public isolated client class Client {
     #               (#https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf))
     # + closeMessage - A message indicating the reason for closing the channel
     # + return - A `rabbitmq:Error` if an I/O error occurred or else `()`
-    isolated function close(int? closeCode = (), string? closeMessage = ()) returns Error? =
+    isolated remote function close(int? closeCode = (), string? closeMessage = ()) returns Error? =
     @java:Method {
         'class: "org.ballerinalang.messaging.rabbitmq.util.ChannelUtils"
     } external;
@@ -212,7 +212,7 @@ public isolated client class Client {
     #               (#https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf))
     # + closeMessage - A message indicating the reason for closing the channel
     # + return - A `rabbitmq:Error` if an I/O error is encountered or else `()`
-    isolated function 'abort(int? closeCode = (), string? closeMessage = ()) returns Error? =
+    isolated remote function 'abort(int? closeCode = (), string? closeMessage = ()) returns Error? =
     @java:Method {
         'class: "org.ballerinalang.messaging.rabbitmq.util.ChannelUtils"
     } external;

--- a/rabbitmq-ballerina/client.bal
+++ b/rabbitmq-ballerina/client.bal
@@ -205,7 +205,7 @@ public isolated client class Client {
     # Aborts the RabbitMQ `rabbitmq:Client`. Forces the `rabbitmq:Client` to close and waits for all the close operations
     # to complete. Any encountered exceptions in the close operations are discarded silently.
     # ```ballerina
-    # check rabbitmqClient->abort(320, "Client Aborted");
+    # check rabbitmqClient->'abort(320, "Client Aborted");
     # ```
     #
     # + closeCode - The close code (for information, go to the [Reply Codes]

--- a/rabbitmq-ballerina/tests/rabbitmq_client_negative_tests.bal
+++ b/rabbitmq-ballerina/tests/rabbitmq_client_negative_tests.bal
@@ -44,7 +44,7 @@ public isolated function testConnectionNegative2() returns error? {
 public isolated function testQueueDeleteNegative() returns error? {
     string queue = "testQueueDeleteNegative";
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
-    check newClient.close(200, "Client closed");
+    check newClient->close(200, "Client closed");
     error? deleteResult = newClient->queueDelete(queue);
     if !(deleteResult is error) {
         test:assertFail("Error expected when trying to delete a non existent queue.");
@@ -59,7 +59,7 @@ public isolated function testQueueConfigNegative() returns error? {
     string queueName = "testQueueConfigNegative";
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
     QueueConfig queueConfig = { durable: true, exclusive: true, autoDelete: false };
-    check newClient.close();
+    check newClient->close();
     Error? result = newClient->queueDeclare(queueName, config = queueConfig);
     if !(result is error) {
        test:assertFail("Error expected when when trying to create a queue.");
@@ -73,7 +73,7 @@ public isolated function testQueueConfigNegative() returns error? {
 public isolated function testExchangeDeclareNegative() returns error? {
     string name = "testExchangeDeclareNegative";
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
-    check newClient.close();
+    check newClient->close();
     Error? result = newClient->exchangeDeclare(name, DIRECT_EXCHANGE);
     if !(result is error) {
        test:assertFail("Error expected when trying to create a direct exchange.");
@@ -86,7 +86,7 @@ public isolated function testExchangeDeclareNegative() returns error? {
 }
 public isolated function testQueueAutoGenerateNegative() returns error? {
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
-    check newClient.close();
+    check newClient->close();
     Error|string queueResult = newClient->queueAutoGenerate();
     if !(queueResult is error) {
         test:assertFail("Error expected when  when trying to create an auto generated queue.");
@@ -103,7 +103,7 @@ public isolated function testClientConsumeNegative() returns error? {
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
     check newClient->queueDeclare(queue);
     check newClient->publishMessage({ content: message.toBytes(), routingKey: queue });
-    check newClient.close();
+    check newClient->close();
     Message|Error consumeResult = newClient->consumeMessage(queue, false);
     if consumeResult is Message {
         test:assertFail("Error expected when trying to consume messages using client.");
@@ -125,7 +125,7 @@ public isolated function testClientBasicAckNegative() returns error? {
         string messageContent = check 'string:fromBytes(consumeResult.content);
         log:printInfo("The message received: " + messageContent);
         test:assertEquals(messageContent, message, msg = "Message received does not match.");
-        check newClient.close();
+        check newClient->close();
         Error? ackResult = newClient->basicAck(consumeResult, false);
         if !(ackResult is Error) {
             test:assertFail("Error expected when trying to acknowledge the message using client.");
@@ -150,7 +150,7 @@ public isolated function testClientBasicNackNegative() returns error? {
         string messageContent = check 'string:fromBytes(consumeResult.content);
         test:assertEquals(messageContent, message, msg = "Message received does not match.");
         log:printInfo("The message received: " + messageContent);
-        check newClient.close();
+        check newClient->close();
         Error? ackResult = newClient->basicNack(consumeResult, false, false);
         if !(ackResult is Error) {
             test:assertFail("Error expected when trying to acknowledge the message using client.");
@@ -170,7 +170,7 @@ public isolated function testQueueBindNegative() returns error? {
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
     check newClient->exchangeDeclare(exchange, DIRECT_EXCHANGE);
     check newClient->queueDeclare(queue);
-    check newClient.close();
+    check newClient->close();
     Error? result = newClient->queueBind(queue, exchange, "myBinding");
     if !(result is error) {
         test:assertFail("Error expected when trying to bind a queue.");
@@ -186,7 +186,7 @@ public isolated function testPublishNegative() returns error? {
     string message = "Test client publish negative";
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
     check newClient->queueDeclare(queue);
-    check newClient.close();
+    check newClient->close();
     error? pubResult = newClient->publishMessage({ content: message.toBytes(), routingKey: queue });
     if !(pubResult is error) {
         test:assertFail("Error expected when trying to publish messages using client.");
@@ -199,8 +199,8 @@ public isolated function testPublishNegative() returns error? {
 }
 public isolated function testCloseNegative() returns error? {
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
-    check newClient.close();
-    error? closeResult = newClient.close();
+    check newClient->close();
+    error? closeResult = newClient->close();
     if !(closeResult is error) {
        test:assertFail("Error expected when trying to close the client twice.");
     }

--- a/rabbitmq-ballerina/tests/rabbitmq_client_tests.bal
+++ b/rabbitmq-ballerina/tests/rabbitmq_client_tests.bal
@@ -84,7 +84,7 @@ public function testClient() returns error? {
         flag = true;
     }
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
-    check newClient.close();
+    check newClient->close();
     test:assertTrue(flag, msg = "RabbitMQ Connection creation failed.");
 }
 
@@ -125,7 +125,7 @@ public isolated function testProducerTransactional() returns error? {
     } else {
         test:assertFail("Error when trying to consume messages using client.");
     }
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -273,7 +273,7 @@ public isolated function testQueueAutoGenerate() returns error? {
     } else {
         log:printInfo("Auto generated queue name: " + queueResult);
     }
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -286,7 +286,7 @@ public isolated function testDirectExchangeDeclare() returns error? {
     if result is error {
        test:assertFail("Error when trying to create a direct exchange.");
     }
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -299,7 +299,7 @@ public isolated function testTopicExchangeDeclare() returns error? {
     if result is error {
        test:assertFail("Error when trying to create a topic exchange.");
     }
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -312,7 +312,7 @@ public isolated function testFanoutExchangeDeclare() returns error? {
     if result is error {
        test:assertFail("Error when trying to create a fanout exchange.");
     }
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -328,7 +328,7 @@ public isolated function testQueueConfig() returns error? {
        test:assertFail("Error when trying to create a queue with config.");
     }
     check newClient->queueDelete(queueName);
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -344,7 +344,7 @@ public isolated function testExchangeConfig() returns error? {
        test:assertFail("Error when trying to create an exchange with options.");
     }
     check newClient->exchangeDelete(exchangeName);
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -361,7 +361,7 @@ public isolated function testQueueBind() returns error? {
     if result is error {
         test:assertFail("Error when trying to bind a queue.");
     }
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -377,7 +377,7 @@ public isolated function testAuthentication() returns error? {
     if newClient is Error {
         test:assertFail("Error when trying to initialize a client with auth.");
     } else {
-        check newClient.close();
+        check newClient->close();
     }
 }
 
@@ -403,7 +403,7 @@ public isolated function testClientBasicAck() returns error? {
     } else {
         test:assertFail("Error when trying to consume messages using client.");
     }
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -423,7 +423,7 @@ public isolated function testConnectionConfig() returns error? {
     if newClient is error {
         test:assertFail("Error when trying to connect.");
     } else {
-        check newClient.close();
+        check newClient->close();
     }
 }
 
@@ -449,7 +449,7 @@ public isolated function testClientBasicNack() returns error? {
     } else {
         test:assertFail("Error when trying to consume messages using client.");
     }
-    check newClient.close();
+    check newClient->close();
 }
 
 @test:Config {
@@ -464,7 +464,7 @@ public isolated function testQueueDelete() returns error? {
     if deleteResult is Error {
         test:assertFail("Error when trying to delete a queue.");
     }
-    check newClient.close(200, "Client closed");
+    check newClient->close(200, "Client closed");
 }
 
 @test:Config {
@@ -476,7 +476,7 @@ public isolated function testExchangeDelete() returns error? {
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
     check newClient->exchangeDeclare(exchange, DIRECT_EXCHANGE);
     Error? deleteExchange = newClient->exchangeDelete(exchange);
-    check newClient.close(200, "Client closed");
+    check newClient->close(200, "Client closed");
 }
 
 @test:Config {
@@ -487,7 +487,7 @@ public isolated function testExchangeDeleteNegative() returns error? {
     string exchange = "testExchangeDeleteNegative";
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
     check newClient->exchangeDeclare(exchange, DIRECT_EXCHANGE);
-    check newClient.close(200, "Client closed");
+    check newClient->close(200, "Client closed");
     Error? deleteExchange = newClient->exchangeDelete(exchange);
     if !(deleteExchange is error) {
         test:assertFail("Error expected when deleting with closed channel.");
@@ -500,7 +500,7 @@ public isolated function testExchangeDeleteNegative() returns error? {
 }
 public isolated function testClientAbort() returns error? {
     Client newClient = check new(DEFAULT_HOST, DEFAULT_PORT);
-    Error? abortResult = newClient.'abort(200, "Client aborted");
+    Error? abortResult = newClient->'abort(200, "Client aborted");
     if abortResult is Error {
         test:assertFail("Error when trying to abort a client.");
     }

--- a/rabbitmq-ballerina/tests/ssl_tests.bal
+++ b/rabbitmq-ballerina/tests/ssl_tests.bal
@@ -39,6 +39,6 @@ public isolated function testSslConnection() returns error? {
     if newClient is Error {
         test:assertFail("Error when trying to create a client with secure connection.");
     } else {
-        check newClient.close();
+        check newClient->close();
     }
 }


### PR DESCRIPTION
## API CHANGE ALERT
`someClient.close()` to `someClient->close()`

## Purpose
$title

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
