### PR TITLE
Add support for intersection types

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/rabbitmq/plugin/RabbitmqCompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/rabbitmq/plugin/RabbitmqCompilerPluginTest.java
@@ -120,6 +120,14 @@ public class RabbitmqCompilerPluginTest {
     }
 
     @Test
+    public void testValidService7() {
+        Package currentPackage = loadPackage("valid_service_7");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errors().size(), 0);
+    }
+
+    @Test
     public void testInvalidService4() {
         Package currentPackage = loadPackage("invalid_service_4");
         PackageCompilation compilation = currentPackage.getCompilation();
@@ -261,6 +269,19 @@ public class RabbitmqCompilerPluginTest {
         Assert.assertEquals(diagnosticResult.errors().size(), 1);
         Diagnostic diagnostic = (Diagnostic) diagnosticResult.errors().toArray()[0];
         assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_FUNCTION);
+    }
+
+    @Test
+    public void testInvalidService16() {
+        Package currentPackage = loadPackage("invalid_service_16");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        Assert.assertEquals(diagnosticResult.errors().size(), 3);
+        Object[] diagnostics = diagnosticResult.errors().toArray();
+        for (Object obj : diagnostics) {
+            Diagnostic diagnostic = (Diagnostic) obj;
+            assertDiagnostic(diagnostic, PluginConstants.CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE);
+        }
     }
 
     private Package loadPackage(String path) {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "rabbitmq_test"
+name = "invalid_service_16"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/invalid_service_16/service.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/rabbitmq;
+
+listener rabbitmq:Listener channelListener =
+        new(rabbitmq:DEFAULT_HOST, rabbitmq:DEFAULT_PORT);
+
+@rabbitmq:ServiceConfig {
+    queueName: "MyQueue"
+}
+service rabbitmq:Service on channelListener {
+    remote function onMessage(readonly & rabbitmq:Client message) {
+    }
+}
+
+@rabbitmq:ServiceConfig {
+    queueName: "MyQueue"
+}
+service rabbitmq:Service on channelListener {
+    remote function onMessage(readonly & byte[] message) {
+    }
+}
+
+@rabbitmq:ServiceConfig {
+    queueName: "MyQueue"
+}
+service rabbitmq:Service on channelListener {
+    remote function onMessage(readonly & string message) {
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_7/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_7/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "rabbitmq_test"
+name = "valid_service_7"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_7/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/valid_service_7/service.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/rabbitmq;
+
+listener rabbitmq:Listener channelListener =
+        new(rabbitmq:DEFAULT_HOST, rabbitmq:DEFAULT_PORT);
+
+@rabbitmq:ServiceConfig {
+    queueName: "MyQueue"
+}
+service rabbitmq:Service on channelListener {
+    remote function onMessage(readonly & rabbitmq:Message message) {
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/rabbitmq/plugin/RabbitmqFunctionValidator.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/rabbitmq/plugin/RabbitmqFunctionValidator.java
@@ -19,6 +19,7 @@
 package io.ballerina.stdlib.rabbitmq.plugin;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
@@ -170,11 +171,36 @@ public class RabbitmqFunctionValidator {
                             CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
                             DiagnosticSeverity.ERROR, requiredParameterNode.location()));
                 }
+            } else if (parameterSymbol.typeDescriptor().typeKind() == TypeDescKind.INTERSECTION) {
+                IntersectionTypeSymbol intersectionTypeSymbol =
+                        (IntersectionTypeSymbol) parameterSymbol.typeDescriptor();
+                // check if nats:Message is included in the intersection
+                validateIntersectionType(intersectionTypeSymbol, requiredParameterNode);
             } else {
                 context.reportDiagnostic(PluginUtils.getDiagnostic(
                         CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
                         DiagnosticSeverity.ERROR, requiredParameterNode.location()));
             }
+        }
+    }
+
+    private void validateIntersectionType(IntersectionTypeSymbol intersectionTypeSymbol,
+                                          RequiredParameterNode requiredParameterNode) {
+        // (readonly & nats:Message - valid, readonly & nats:Client - invalid)
+        // (readonly & string - invalid)
+        TypeReferenceTypeSymbol typeReferenceTypeSymbol = null;
+        int hasType = 0;
+        List<TypeSymbol> intersectionMembers = intersectionTypeSymbol.memberTypeDescriptors();
+        for (TypeSymbol typeSymbol : intersectionMembers) {
+            if (typeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+                typeReferenceTypeSymbol = (TypeReferenceTypeSymbol) typeSymbol;
+                hasType++;
+            }
+        }
+        if (hasType != 1 || !isValidParamTypeMessage(typeReferenceTypeSymbol)) {
+            context.reportDiagnostic(PluginUtils.getDiagnostic(
+                    CompilationErrors.INVALID_FUNCTION_PARAM_MESSAGE,
+                    DiagnosticSeverity.ERROR, requiredParameterNode.location()));
         }
     }
 


### PR DESCRIPTION
## Purpose

- Add compiler plugin support for intersection types.
- Support intersection types in runtime impl.

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/2611

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
