### PR TITLE
Disable tests for Windows

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -28,4 +28,4 @@ jobs:
       lang_version: ${{ inputs.lang_version }}
       native_image_options: ${{ inputs.native_image_options }}
       additional_ubuntu_build_flags: '-x :rabbitmq-compiler-plugin-tests:test'
-      additional_windows_build_flags: '-x :rabbitmq-compiler-plugin-tests:test'
+      additional_windows_build_flags: '-x test'


### PR DESCRIPTION
## Purpose

> $Subject

Running ballerina tests in Windows is [by default disabled in Windows for pull requests](https://github.com/ballerina-platform/module-ballerinax-rabbitmq/blob/13c11aa0a11200bf0fbc5ba96128328b8cbff8fb/.github/workflows/pull-request.yml#L42). Same should be done for the `bal test --native` workflow

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
