### PR TITLE
Fix error in passing additional arguments to queue declare

### DIFF
--- a/ballerina/tests/rabbitmq_client_tests.bal
+++ b/ballerina/tests/rabbitmq_client_tests.bal
@@ -411,9 +411,13 @@ public isolated function testDeclareQueueWithArgsNegative() returns error? {
     error? result = newClient->queueDeclare(queue, { arguments: args });
     if result !is error {
         test:assertFail("Error when trying to consume messages using client.");
+    } else {
+        string expectedError = "Error occurred while declaring the queue: Unsupported type in arguments map passed "
+                        + "while declaring a queue.";
+        test:assertEquals(result.message(), expectedError,
+                    msg = "Error message mismatch in declaring queue with invalid args.");
     }
-    check newClient->close();
-    return;
+    return newClient->close();
 }
 
 @test:Config {
@@ -428,8 +432,7 @@ public isolated function testProducerTransactionalRollback() returns error? {
     if consumeResult is Message {
         test:assertFail("Rolled back message is in queue.");
     }
-    check newClient->close();
-    return;
+    return newClient->close();
 }
 
 isolated function rabbitMQTransactionFail(string queue) returns error? {

--- a/ballerina/tests/rabbitmq_client_tests.bal
+++ b/ballerina/tests/rabbitmq_client_tests.bal
@@ -380,6 +380,46 @@ public isolated function testProducerTransactional() returns error? {
     dependsOn: [testClient],
     groups: ["rabbitmq"]
 }
+public isolated function testDeclareQueueWithArgs() returns error? {
+    string queue = "declareArgs";
+    Client newClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+    map<anydata> args = {
+        "x-message-ttl": 60000,
+        "x-expires": 800000
+    };
+    check newClient->queueDeclare(queue, { arguments: args });
+    check newClient->close();
+    return;
+}
+
+@test:Config {
+    dependsOn: [testClient],
+    groups: ["rabbitmq"]
+}
+public isolated function testDeclareQueueWithArgsNegative() returns error? {
+    string queue = "declareArgs";
+    Client newClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+
+    map<int> m = {
+        "x": 1,
+        "y": 2
+    };
+    map<anydata> args = {
+        "x-message-ttl": m,
+        "x-expires": 800000
+    };
+    error? result = newClient->queueDeclare(queue, { arguments: args });
+    if result !is error {
+        test:assertFail("Error when trying to consume messages using client.");
+    }
+    check newClient->close();
+    return;
+}
+
+@test:Config {
+    dependsOn: [testClient],
+    groups: ["rabbitmq"]
+}
 public isolated function testProducerTransactionalRollback() returns error? {
     string queue = "testProducerTransactionalRollback";
     Client newClient = check new (DEFAULT_HOST, DEFAULT_PORT);

--- a/ballerina/tests/rabbitmq_client_tests.bal
+++ b/ballerina/tests/rabbitmq_client_tests.bal
@@ -397,7 +397,7 @@ public isolated function testDeclareQueueWithArgs() returns error? {
     groups: ["rabbitmq"]
 }
 public isolated function testDeclareQueueWithArgsNegative() returns error? {
-    string queue = "declareArgs";
+    string queue = "declareArgs2";
     Client newClient = check new (DEFAULT_HOST, DEFAULT_PORT);
 
     map<int> m = {

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - [API docs updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 
+### Fixed
+- [Fix error in passing additional arguments when declaring a queue.](https://github.com/ballerina-platform/ballerina-standard-library/issues/3686)
+
 ### Added
 - [Add support for virtual host configuration in connection config.](https://github.com/ballerina-platform/ballerina-standard-library/issues/3658)
 

--- a/native/src/main/java/io/ballerina/stdlib/rabbitmq/RabbitMQUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/rabbitmq/RabbitMQUtils.java
@@ -70,6 +70,12 @@ public class RabbitMQUtils {
                                                 StringUtils.fromString(errorMessage));
     }
 
+    public static BError returnErrorValueWithCause(String errorMessage, BError cause) {
+        return ErrorCreator.createDistinctError(RabbitMQConstants.RABBITMQ_ERROR,
+                getModule(),
+                StringUtils.fromString(errorMessage), cause);
+    }
+
     public static BError createPayloadValidationError(String message, Object results) {
         return ErrorCreator.createError(getModule(), PAYLOAD_VALIDATION_ERROR, StringUtils.fromString(message),
                 ErrorCreator.createError(StringUtils.fromString(results.toString())), null);

--- a/native/src/main/java/io/ballerina/stdlib/rabbitmq/util/ChannelUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/rabbitmq/util/ChannelUtils.java
@@ -26,6 +26,7 @@ import com.rabbitmq.client.ShutdownSignalException;
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BDecimal;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
@@ -87,7 +88,7 @@ public class ChannelUtils {
         boolean durable = false;
         boolean exclusive = false;
         boolean autoDelete = true;
-        Map<String, Object> argumentsMap = null;
+        Map<String, Object> argumentsMap = new HashMap<>();
         Channel channel = (Channel) clientObj.getNativeData(RabbitMQConstants.CHANNEL_NATIVE_OBJECT);
         try {
             if (queueConfig != null) {
@@ -97,18 +98,34 @@ public class ChannelUtils {
                 exclusive = config.getBooleanValue(RabbitMQConstants.QUEUE_EXCLUSIVE);
                 autoDelete = config.getBooleanValue(RabbitMQConstants.QUEUE_AUTO_DELETE);
                 if (config.getMapValue(RabbitMQConstants.QUEUE_ARGUMENTS) != null) {
-                    argumentsMap = (HashMap<String, Object>) config.getMapValue(RabbitMQConstants.QUEUE_ARGUMENTS);
+                    @SuppressWarnings(RabbitMQConstants.UNCHECKED)
+                    HashMap<BString, Object> queueArgs =
+                            (HashMap<BString, Object>) config.getMapValue(RabbitMQConstants.QUEUE_ARGUMENTS);
+                    queueArgs.forEach((k, v) -> argumentsMap.put(k.getValue(), getConvertedValue(v)));
                 }
             }
             channel.queueDeclare(queueName.getValue(), durable, exclusive, autoDelete, argumentsMap);
             RabbitMQMetricsUtil.reportNewQueue(channel, queueName.getValue());
             RabbitMQTracingUtil.traceQueueResourceInvocation(channel, queueName.getValue(), environment);
-        } catch (IOException | ShutdownSignalException exception) {
+        } catch (IOException | ShutdownSignalException | BError exception) {
             RabbitMQMetricsUtil.reportError(channel, RabbitMQObservabilityConstants.ERROR_TYPE_QUEUE_DECLARE);
             return RabbitMQUtils.returnErrorValue("Error occurred while declaring the queue: "
                                                           + exception.getMessage());
         }
         return null;
+    }
+
+    private static Object getConvertedValue(Object v) {
+        if (v instanceof BString) {
+            return ((BString) v).getValue();
+        } else if (v instanceof BDecimal) {
+            return ((BDecimal) v).decimalValue();
+        } else if (v instanceof Long) {
+            return ((Long) v).intValue();
+        } else {
+            throw RabbitMQUtils.returnErrorValue(
+                    "Unsupported type in arguments map passed while declaring a queue.");
+        }
     }
 
     public static Object queueAutoGenerate(BObject clientObj) {


### PR DESCRIPTION
## Purpose
**Description:**
When trying to declare a queue with additional arguments passed to the `arguments` field in `QueueConfig`, the client crashes giving an error. 
fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3686

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- <s>[ ] Updated the spec </s>
- <s>[ ] Checked native-image compatibility </s>
