### PR TITLE
Support client acknowledgments for AnydataMessage

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -162,7 +162,7 @@ public isolated client class Client {
     # + multiple - Set to `true` to acknowledge all messages up to and including the called on message and
     #              `false` to acknowledge just the called on message
     # + return - A `rabbitmq:Error` if an I/O error occurred or else `()`
-    isolated remote function basicAck(Message message, boolean multiple = false) returns Error? =
+    isolated remote function basicAck(Message|AnydataMessage message, boolean multiple = false) returns Error? =
     @java:Method {
         'class: "io.ballerina.stdlib.rabbitmq.util.ChannelUtils"
     } external;
@@ -177,7 +177,7 @@ public isolated client class Client {
     #              `false` to reject just the called on message
     # + requeue - `true` if the rejected message(s) should be re-queued rather than discarded/dead-lettered
     # + return - A `rabbitmq:Error` if an I/O error occurred or else `()`
-    isolated remote function basicNack(Message message, boolean multiple = false, boolean requeue = true)
+    isolated remote function basicNack(Message|AnydataMessage message, boolean multiple = false, boolean requeue = true)
                             returns Error? =
     @java:Method {
         'class: "io.ballerina.stdlib.rabbitmq.util.ChannelUtils"

--- a/ballerina/tests/data_binding_consume_tests.bal
+++ b/ballerina/tests/data_binding_consume_tests.bal
@@ -46,6 +46,54 @@ function floatConsumeMessageTest() returns error? {
     check 'client->close();
 }
 
+@test:Config {
+    dependsOn: [stringConsumeMessageTest]
+}
+function stringConsumeMessageTestWithAck() returns error? {
+    string message = "This is a data binding related message";
+    check produceMessage(message.toString(), DATA_BINDING_STRING_CONSUME_QUEUE);
+    Client 'client = check new (DEFAULT_HOST, DEFAULT_PORT);
+    StringMessage receivedMessage = check 'client->consumeMessage(DATA_BINDING_STRING_CONSUME_QUEUE, false);
+    test:assertEquals(receivedMessage.content, message);
+    error? result = 'client->basicAck(receivedMessage);
+    if result is error {
+        test:assertFail("Acknowledging the message with data binding failed.");
+    }
+    check 'client->close();
+}
+
+@test:Config {
+    dependsOn: [intConsumeMessageTest]
+}
+function intConsumeMessageTestWithAck() returns error? {
+    int message = 445;
+    check produceMessage(message.toString(), DATA_BINDING_INT_CONSUME_QUEUE);
+    Client 'client = check new (DEFAULT_HOST, DEFAULT_PORT);
+    IntMessage receivedMessage = check 'client->consumeMessage(DATA_BINDING_INT_CONSUME_QUEUE, false);
+    test:assertEquals(receivedMessage.content, message);
+    error? result = 'client->basicAck(receivedMessage);
+    if result is error {
+        test:assertFail("Acknowledging the message with data binding failed.");
+    }
+    check 'client->close();
+}
+
+@test:Config {
+    dependsOn: [floatConsumeMessageTest]
+}
+function floatConsumeMessageTestWithAck() returns error? {
+    float message = 43.201;
+    check produceMessage(message.toString(), DATA_BINDING_FLOAT_CONSUME_QUEUE);
+    Client 'client = check new (DEFAULT_HOST, DEFAULT_PORT);
+    FloatMessage receivedMessage = check 'client->consumeMessage(DATA_BINDING_FLOAT_CONSUME_QUEUE, false);
+    test:assertEquals(receivedMessage.content, message);
+    error? result = 'client->basicNack(receivedMessage);
+    if result is error {
+        test:assertFail("Acknowledging the message with data binding failed.");
+    }
+    check 'client->close();
+}
+
 @test:Config {}
 function decimalConsumeMessageTest() returns error? {
     decimal message = 59.382;

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [API docs updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
 
 ### Added
+- [Add support for AnydataMessage in client acknowledgment APIs.](https://github.com/ballerina-platform/ballerina-standard-library/issues/3685)
 - [Add support for virtual host configuration in connection config.](https://github.com/ballerina-platform/ballerina-standard-library/issues/3658)
 
 ## [2.4.0] - 2022-09-08


### PR DESCRIPTION
## Purpose
The RabbitMQ client can consume messages by using the two client APIs `consumeMessage` and `consumePayload`. If you want to acknowledge the message received you should use the `basicAck` method provided by the client which only supports the deprecated `Message` record as the parameter. Therefore the user can't use data binding along with manual acknowledgements. This PR is to fix that. 
fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3685

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- <s>[ ] Updated the spec</s>
- <s>[ ] Checked native-image compatibility</s>
