### PR TITLE
Default queues and exchanges to durable and non-auto-delete (RabbitMQ 4.x compatibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- [Declare queues and exchanges as durable and non-auto-delete by default](https://github.com/ballerina-platform/ballerina-library/issues/8828). RabbitMQ 4.3+ [denies transient non-exclusive queues by default](https://www.rabbitmq.com/release-information/deprecated-features-list), and [all transient entities will be removed with Mnesia later in the 4.x series](https://github.com/rabbitmq/rabbitmq-server/discussions/13161).
+
 ### Added
 
 - [Add support for configurable consumer tag with fallback to auto-generated value](https://github.com/ballerina-platform/ballerina-library/issues/8799)

--- a/README.md
+++ b/README.md
@@ -50,22 +50,22 @@ Client applications work with exchanges and queues, which are the high-level bui
 ```
 
 This sample code will declare,
-- a durable auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`
-- a non-durable, exclusive auto-delete queue with an auto-generated name
+- a durable, non-auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`
+- a durable, non-exclusive, non-auto-delete queue with the given name
 
 Next, the `queueBind` function is called to bind the queue to the exchange with the given routing key.
 
 ```ballerina
     check rabbitmqClient->exchangeDeclare("MyExchange", rabbitmq:DIRECT_EXCHANGE);
-    check rabbitmqClient->queueDeclare("MyQueue", { durable: true,
-                                                   exclusive: false,
-                                                   autoDelete: false });
+    check rabbitmqClient->queueDeclare("MyQueue", { durable: false,
+                                                   exclusive: true,
+                                                   autoDelete: true });
     check rabbitmqClient->queueBind("MyQueue", "MyExchange", "routing-key");
 ```
 
 This sample code will declare,
-- a durable auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`
-- a durable, non-exclusive, non-auto-delete queue with a well-known name
+- a durable, non-auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`
+- a transient, exclusive, auto-delete queue with a well-known name
 
 #### Delete entities and purge queues
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "rabbitmq"
-version = "3.5.0"
+version = "3.6.0"
 authors = ["Ballerina"]
 keywords = ["service", "client", "messaging", "network", "pubsub", "Vendor/RabbitMQ", "Area/Messaging", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-rabbitmq"
@@ -18,8 +18,8 @@ path = "./lib/amqp-client-5.18.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "rabbitmq-native"
-version = "3.5.0"
-path = "../native/build/libs/rabbitmq-native-3.5.0-SNAPSHOT.jar"
+version = "3.6.0"
+path = "../native/build/libs/rabbitmq-native-3.6.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "rabbitmq-compiler-plugin"
 class = "io.ballerina.stdlib.rabbitmq.plugin.RabbitmqCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/rabbitmq-compiler-plugin-3.5.0-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/rabbitmq-compiler-plugin-3.6.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -402,7 +402,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "rabbitmq"
-version = "3.5.0"
+version = "3.6.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "crypto"},

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -50,22 +50,22 @@ Client applications work with exchanges and queues, which are the high-level bui
 ```
 
 This sample code will declare,
-- a durable auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`
-- a non-durable, exclusive auto-delete queue with an auto-generated name
+- a durable, non-auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`
+- a durable, non-exclusive, non-auto-delete queue with the given name
 
 Next, the `queueBind` function is called to bind the queue to the exchange with the given routing key.
 
 ```ballerina
     check rabbitmqClient->exchangeDeclare("MyExchange", rabbitmq:DIRECT_EXCHANGE);
-    check rabbitmqClient->queueDeclare("MyQueue", { durable: true,
-                                                   exclusive: false,
-                                                   autoDelete: false });
+    check rabbitmqClient->queueDeclare("MyQueue", { durable: false,
+                                                   exclusive: true,
+                                                   autoDelete: true });
     check rabbitmqClient->queueBind("MyQueue", "MyExchange", "routing-key");
 ```
 
 This sample code will declare,
-- a durable auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`
-- a durable, non-exclusive, non-auto-delete queue with a well-known name
+- a durable, non-auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`
+- a transient, exclusive, auto-delete queue with a well-known name
 
 #### Delete entities and purge queues
 

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -113,7 +113,7 @@ task startRabbitmqServer() {
                 println "Waiting for RabbitMQ to be ready..."
                 while (retries < maxRetries && !serverReady) {
                     try {
-                        def url = new URL("http://localhost:15672/api/aliveness-test/%2F")
+                        def url = new URL("http://localhost:15672/api/health/checks/local-alarms")
                         def connection = (HttpURLConnection) url.openConnection()
                         connection.setRequestProperty("Authorization", "Basic " +
                             Base64.encoder.encodeToString("guest:guest".getBytes()))

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -34,7 +34,7 @@ public isolated client class Client {
         return createChannel(host, port, self, connectionData);
     }
 
-    # Declares a non-exclusive, auto-delete, and non-durable queue with the given configurations.
+    # Declares a non-exclusive, non-auto-delete, and durable queue with the given configurations.
     # ```ballerina
     # check rabbitmqClient->queueDeclare("MyQueue");
     # ```
@@ -60,7 +60,7 @@ public isolated client class Client {
         'class: "io.ballerina.stdlib.rabbitmq.util.ChannelUtils"
     } external;
 
-    # Declares a non-auto-delete, non-durable exchange with no extra arguments.
+    # Declares a non-auto-delete, durable exchange with no extra arguments.
     # If the arguments are specified, then the exchange is declared accordingly.
     # ```ballerina
     # check rabbitmqClient->exchangeDeclare("MyExchange", rabbitmq:DIRECT_EXCHANGE);

--- a/ballerina/rabbitmq_commons.bal
+++ b/ballerina/rabbitmq_commons.bal
@@ -54,9 +54,9 @@ public type BasicProperties record {|
 
 # Additional configurations used to declare a queue.
 #
-# + durable - Set to true if declaring a durable queue (defaults to `true`)
+# + durable - Set to true if declaring a durable queue
 # + exclusive - Set to true if declaring an exclusive queue
-# + autoDelete - Set to true if declaring an auto-delete queue (defaults to `false`)
+# + autoDelete - Set to true if declaring an auto-delete queue
 # + arguments - Other properties (construction arguments) of the queue
 public type QueueConfig record {|
     boolean durable = true;
@@ -67,7 +67,7 @@ public type QueueConfig record {|
 
 # Additional configurations used to declare an exchange.
 #
-# + durable - Set to `true` if a durable exchange is declared (defaults to `true`)
+# + durable - Set to `true` if a durable exchange is declared
 # + autoDelete - Set to `true` if an auto-delete exchange is declared
 # + arguments - Other properties (construction arguments) for the queue
 public type ExchangeConfig record {|

--- a/ballerina/rabbitmq_commons.bal
+++ b/ballerina/rabbitmq_commons.bal
@@ -54,24 +54,24 @@ public type BasicProperties record {|
 
 # Additional configurations used to declare a queue.
 #
-# + durable - Set to true if declaring a durable queue
+# + durable - Set to true if declaring a durable queue (defaults to `true`)
 # + exclusive - Set to true if declaring an exclusive queue
-# + autoDelete - Set to true if declaring an auto-delete queue
+# + autoDelete - Set to true if declaring an auto-delete queue (defaults to `false`)
 # + arguments - Other properties (construction arguments) of the queue
 public type QueueConfig record {|
-    boolean durable = false;
+    boolean durable = true;
     boolean exclusive = false;
-    boolean autoDelete = true;
+    boolean autoDelete = false;
     map<anydata> arguments?;
 |};
 
 # Additional configurations used to declare an exchange.
 #
-# + durable - Set to `true` if a durable exchange is declared
+# + durable - Set to `true` if a durable exchange is declared (defaults to `true`)
 # + autoDelete - Set to `true` if an auto-delete exchange is declared
 # + arguments - Other properties (construction arguments) for the queue
 public type ExchangeConfig record {|
-    boolean durable = false;
+    boolean durable = true;
     boolean autoDelete = false;
     map<anydata> arguments?;
 |};

--- a/ballerina/tests/rabbitmq_client_tests.bal
+++ b/ballerina/tests/rabbitmq_client_tests.bal
@@ -821,6 +821,93 @@ public isolated function testExchangeConfig() returns error? {
 }
 
 @test:Config {
+    dependsOn: [testClient, testQueueDelete],
+    groups: ["rabbitmq"]
+}
+public isolated function testDefaultQueueIsDurable() returns error? {
+    // RabbitMQ 4.3+ denies transient (non-durable) non-exclusive queues by default.
+    // The default is durable and non-exclusive
+    string queueName = "testDefaultQueueIsDurable";
+    Client newClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+    Error? result = newClient->queueDeclare(queueName);
+    if result is error {
+        test:assertFail("Default queue declaration should succeed (durable by default) on RabbitMQ 4.x.");
+    }
+    check newClient->queueDelete(queueName);
+    check newClient->close();
+    return;
+}
+
+@test:Config {
+    dependsOn: [testClient, testExchangeDelete],
+    groups: ["rabbitmq"]
+}
+public isolated function testDefaultExchangeIsDurable() returns error? {
+    string exchangeName = "testDefaultExchangeIsDurable";
+    Client newClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+    // Declaring with no config uses the default, which is durable.
+    Error? result = newClient->exchangeDeclare(exchangeName, DIRECT_EXCHANGE);
+    if result is error {
+        test:assertFail("Default exchange declaration should succeed.");
+    }
+    // A separate channel re-declares the same exchange differing ONLY in durability (the
+    // default-declared exchange is non-auto-delete). The declaration must fail with a property
+    // mismatch, which confirms the default-declared exchange is durable.
+    Client verifyClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+    Error? mismatch = verifyClient->exchangeDeclare(exchangeName, DIRECT_EXCHANGE,
+            config = {durable: false, autoDelete: false});
+    test:assertTrue(mismatch is error, msg = "Re-declaring a durable exchange as non-durable should fail.");
+    check newClient->exchangeDelete(exchangeName);
+    check newClient->close();
+    return;
+}
+
+@test:Config {
+    dependsOn: [testClient, testQueueDelete],
+    groups: ["rabbitmq"]
+}
+public isolated function testDefaultQueueIsNotAutoDelete() returns error? {
+    string queueName = "testDefaultQueueIsNotAutoDelete";
+    Client newClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+    // Declaring with no config uses the default, which is now non-auto-delete.
+    Error? result = newClient->queueDeclare(queueName);
+    if result is error {
+        test:assertFail("Default queue declaration should succeed.");
+    }
+    // A separate channel re-declares the same queue differing ONLY in autoDelete.
+    // The declaration must fail with a property mismatch.
+    Client verifyClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+    Error? mismatch = verifyClient->queueDeclare(queueName,
+            config = {durable: true, exclusive: false, autoDelete: true});
+    test:assertTrue(mismatch is error, msg = "Re-declaring a non-auto-delete queue as auto-delete should fail.");
+    check newClient->queueDelete(queueName);
+    check newClient->close();
+    return;
+}
+
+@test:Config {
+    dependsOn: [testClient, testExchangeDelete],
+    groups: ["rabbitmq"]
+}
+public isolated function testDefaultExchangeIsNotAutoDelete() returns error? {
+    string exchangeName = "testDefaultExchangeIsNotAutoDelete";
+    Client newClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+    // Declaring with no config uses the default, which is now non-auto-delete.
+    Error? result = newClient->exchangeDeclare(exchangeName, DIRECT_EXCHANGE);
+    if result is error {
+        test:assertFail("Default exchange declaration should succeed.");
+    }
+    // A separate channel re-declares the same exchange differing ONLY in autoDelete.
+    Client verifyClient = check new (DEFAULT_HOST, DEFAULT_PORT);
+    Error? mismatch = verifyClient->exchangeDeclare(exchangeName, DIRECT_EXCHANGE,
+            config = {durable: true, autoDelete: true});
+    test:assertTrue(mismatch is error, msg = "Re-declaring a non-auto-delete exchange as auto-delete should fail.");
+    check newClient->exchangeDelete(exchangeName);
+    check newClient->close();
+    return;
+}
+
+@test:Config {
     dependsOn: [testClient],
     groups: ["rabbitmq"]
 }
@@ -1336,11 +1423,15 @@ service object {
     }
 };
 
+// Re-declares QUEUE_CONFIG_DUPLICATE (already declared with autoDelete: true) using a
+// mismatching but still-valid (durable, non-exclusive) configuration to trigger a
+// PRECONDITION_FAILED. Note: a transient (durable: false) non-exclusive queue cannot be used
+// here, as RabbitMQ 4.3+ denies that combination outright regardless of the existing queue.
 Service queueConfigDuplicateError =
 @ServiceConfig {
     queueName: QUEUE_CONFIG_DUPLICATE,
     config: {
-        durable: false,
+        durable: true,
         exclusive: false,
         autoDelete: false
     }

--- a/ballerina/tests/server/compose.yaml
+++ b/ballerina/tests/server/compose.yaml
@@ -1,6 +1,6 @@
 services:
     rabbitmq-tls:
-        image: rabbitmq:3.12-management
+        image: rabbitmq:4.3-management
         hostname: rabbitmq-tls
         ports:
             - 15671:15671
@@ -9,13 +9,13 @@ services:
             - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
             - ./certs:/certs
     rabbitmq-1:
-        image: rabbitmq:3.12-management
+        image: rabbitmq:4.3-management
         hostname: rabbitmq-1
         ports:
             - 15672:15672
             - 5672:5672
     rabbitmq-auth:
-        image: rabbitmq:3.12-management
+        image: rabbitmq:4.3-management
         hostname: rabbitmq-auth
         ports:
             - 5673:5672
@@ -23,7 +23,7 @@ services:
         volumes:
             - ./rabbitmq-auth.conf:/etc/rabbitmq/rabbitmq.conf
     rabbitmq-vhost:
-        image: rabbitmq:3.12-management
+        image: rabbitmq:4.3-management
         hostname: rabbitmq-vhost
         ports:
             - 5674:5672

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -236,7 +236,7 @@ Client applications work with exchanges and queues, the high-level building bloc
 ```ballerina
    public type ExchangeConfig record {|
       # Set to `true` if a durable exchange is declared.
-      boolean durable = false;
+      boolean durable = true;
       # Set to `true` if an autodelete exchange is declared.
       boolean autoDelete = false;
       # Other properties (construction arguments) for the queue.
@@ -249,11 +249,11 @@ Client applications work with exchanges and queues, the high-level building bloc
 ```ballerina
    public type QueueConfig record {|
       # Set to true if declaring a durable queue.
-      boolean durable = false;
+      boolean durable = true;
       # Set to true if declaring an exclusive queue.
       boolean exclusive = false;
       # Set to true if declaring an auto-delete queue.
-      boolean autoDelete = true;
+      boolean autoDelete = false;
       # Other properties (construction arguments) of the queue.
       map<anydata> arguments?;
    |};
@@ -264,7 +264,7 @@ Following methods can be used to declare the exchanges, queues and to bind them.
 - `exchangeDeclare`
 
 ```ballerina
-   # Declares a non-auto-delete, non-durable exchange with no extra arguments.
+   # Declares a non-auto-delete, durable exchange with no extra arguments.
    # If the arguments are specified, then the exchange is declared accordingly.
    #
    # + name - The name of the exchange
@@ -278,7 +278,7 @@ Following methods can be used to declare the exchanges, queues and to bind them.
 - `queueDeclare`
 
 ```ballerina
-   # Declares a non-exclusive, auto-delete, or non-durable queue with the given configurations.
+   # Declares a non-exclusive, non-auto-delete, durable queue with the given configurations.
    #
    # + name - The name of the queue
    # + config - The configurations required to declare a queue
@@ -319,21 +319,21 @@ Following methods can be used to declare the exchanges, queues and to bind them.
 
 This code will declare,
 
-- a durable auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`.
-- a non-durable, exclusive auto-delete queue.
+- a durable, non-auto-delete exchange of the type `rabbitmq:DIRECT_EXCHANGE`.
+- a durable, non-exclusive, non-auto-delete queue.
 
 ```ballerina
    check rabbitmqClient->exchangeDeclare("MyExchange", rabbitmq:TOPIC_EXCHANGE);
-   check rabbitmqClient->queueDeclare("MyQueue", { durable: true,
-                                                exclusive: false,
-                                                autoDelete: false });
+   check rabbitmqClient->queueDeclare("MyQueue", { durable: false,
+                                                exclusive: true,
+                                                autoDelete: true });
    check rabbitmqClient->queueBind("MyQueue", "MyExchange", "routing-key");
 ```
 
 This sample code will declare,
 
-- a durable auto-delete exchange of the type `rabbitmq:TOPIC_EXCHANGE`.
-- a durable, non-exclusive, non-auto-delete queue.
+- a durable, non-auto-delete exchange of the type `rabbitmq:TOPIC_EXCHANGE`.
+- a transient, exclusive, auto-delete queue.
 
 The `queueBind` function is called to bind the queue to the exchange with the given routing key. See the API docs for the complete list of supported configurations.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=3.5.0-SNAPSHOT
+version=3.6.0-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 
 amqpClientVersion=5.18.0

--- a/native/src/main/java/io/ballerina/stdlib/rabbitmq/util/ChannelUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/rabbitmq/util/ChannelUtils.java
@@ -89,9 +89,9 @@ public class ChannelUtils {
 
     public static Object queueDeclare(Environment environment, BObject clientObj,
                                       BString queueName, Object queueConfig) {
-        boolean durable = false;
+        boolean durable = true;
         boolean exclusive = false;
-        boolean autoDelete = true;
+        boolean autoDelete = false;
         Map<String, Object> argumentsMap = new HashMap<>();
         Channel channel = (Channel) clientObj.getNativeData(RabbitMQConstants.CHANNEL_NATIVE_OBJECT);
         try {
@@ -231,8 +231,8 @@ public class ChannelUtils {
     public static Object exchangeDeclare(Environment environment, BObject clientObj, BString exchangeName,
                                          BString exchangeType, Object exchangeConfig) {
         Channel channel = (Channel) clientObj.getNativeData(RabbitMQConstants.CHANNEL_NATIVE_OBJECT);
-        boolean durable = false;
-        boolean autoDelete = true;
+        boolean durable = true;
+        boolean autoDelete = false;
         Map<String, Object> argumentsMap = null;
         RabbitMQTracingUtil.traceResourceInvocation(channel, environment);
         try {

--- a/native/src/main/java/io/ballerina/stdlib/rabbitmq/util/ListenerUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/rabbitmq/util/ListenerUtils.java
@@ -174,9 +174,9 @@ public class ListenerUtils {
                         + RabbitMQConstants.SERVICE_CONFIG));
         String queueName = "";
         Map<String, Object> argumentsMap = new HashMap<>();
-        boolean durable = false;
+        boolean durable = true;
         boolean exclusive = false;
-        boolean autoDelete = true;
+        boolean autoDelete = false;
 
 
         if (service.getNativeData(RabbitMQConstants.QUEUE_NAME.getValue()) != null) {


### PR DESCRIPTION
## Purpose

Make the default queue and exchange declarations **durable** and **non-auto-delete**, so the out-of-the-box defaults produce a persistent, named entity — and restore compatibility with RabbitMQ 4.3+.

## Background

RabbitMQ 4.3+ advanced the `transient_nonexcl_queues` deprecated feature to *denied by default*: declaring a non-durable, non-exclusive queue is now rejected with `PRECONDITION_FAILED ... transient_nonexcl_queues is deprecated`. The connector's previous default (`durable = false`) produced exactly that combination, so any queue auto-declared with default config failed on a 4.3+ broker.

## Changes and rationale

``` ballerina
# Additional configurations used to declare a queue.
#
# + durable - Set to true if declaring a durable queue (defaults to `true`)
# + exclusive - Set to true if declaring an exclusive queue
# + autoDelete - Set to true if declaring an auto-delete queue (defaults to `false`)
# + arguments - Other properties (construction arguments) of the queue
public type QueueConfig record {|
    boolean durable = true; // previously `false`
    boolean exclusive = false;
    boolean autoDelete = false; // previously `true`
    map<anydata> arguments?;
|};

# Additional configurations used to declare an exchange.
#
# + durable - Set to `true` if a durable exchange is declared (defaults to `true`)
# + autoDelete - Set to `true` if an auto-delete exchange is declared
# + arguments - Other properties (construction arguments) for the queue
public type ExchangeConfig record {|
    boolean durable = true; // previously `false`
    boolean autoDelete = false; // previously `true`
    map<anydata> arguments?;
|};

```

- **`durable` → `true`** for `QueueConfig` and `ExchangeConfig` (records + native no-config fallbacks).
  - Queues: directly fixes the 4.3+ rejection.
  - Exchanges: forward-looking — RabbitMQ has stated all transient entities will be removed once Khepri becomes the only metadata store — so bundling it now avoids a second breaking change later.
- **`autoDelete` → `false`** for queues (record + fallbacks), and the exchange no-config fallback fixed to match its record (already `false`).
  - A `durable` + `auto-delete` entity is incoherent: it survives a broker restart yet vanishes when the last consumer disconnects. Non-auto-delete is the sane default for a named entity, and this also aligns no-config vs empty-config behavior for exchanges.
- **`exclusive` stays `false`** — shared, scalable consumption. The temporary-queue combination (`transient + exclusive + auto-delete`) remains an explicit opt-in.
- **Version → `3.6.0-SNAPSHOT`.** This is a behavior change, shipped as a minor.
- **Test broker → `rabbitmq:4.3-management`** so the deprecation denial is actually exercised by CI. The readiness probe was switched off `/api/aliveness-test` (which itself declares a transient queue and is denied on 4.3) to `/api/health/checks/local-alarms`.
- **Docs** (spec, both READMEs, API doc comments) updated. The second example in the README/spec now uses the `transient + exclusive + auto-delete` combination, so it no longer duplicates the new defaults.

## Compatibility

Backward-incompatible: re-declaring an existing non-durable / auto-delete queue or exchange with the new defaults raises `PRECONDITION_FAILED` (inequivalent args). Users relying on the old defaults must delete and recreate those entities, or set the properties explicitly.

## Tests

Added `testDefaultQueueIsDurable`, `testDefaultQueueIsNotAutoDelete`, `testDefaultExchangeIsDurable`, and `testDefaultExchangeIsNotAutoDelete`, all run against RabbitMQ 4.3.

Related: ballerina-platform/ballerina-library#8828


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## RabbitMQ Connector Default Declaration Behavior Update

This PR updates the Ballerina RabbitMQ connector to align queue and exchange declaration defaults with RabbitMQ 4.3+ behavior. It changes the default settings for durability and auto-delete so that declarations are non-auto-delete and durable by default, improving compatibility with newer broker constraints.

### Configuration Changes
- **QueueConfig**: `durable` now defaults to `true` (was `false`); `autoDelete` now defaults to `false` (was `true`)
- **ExchangeConfig**: `durable` now defaults to `true` (was `false`)
- Updated **record defaults** and **native fallback implementations** to keep behavior consistent (including correcting exchange `autoDelete` to `false` where applicable)

### Compatibility and Testing
- **Version bump** to `3.6.0-SNAPSHOT` to reflect the behavior change
- Updated the test broker image to **`rabbitmq:4.3-management`** to validate behavior against RabbitMQ 4.3+
- Switched the Docker readiness probe from **`/api/aliveness-test`** to **`/api/health/checks/local-alarms`** to avoid transient queue declarations that are rejected on RabbitMQ 4.3+
- Added four tests:
  - `testDefaultQueueIsDurable`
  - `testDefaultExchangeIsDurable`
  - `testDefaultQueueIsNotAutoDelete`
  - `testDefaultExchangeIsNotAutoDelete`
- Adjusted test configuration to prevent conflicts with the new defaults on RabbitMQ 4.3+

### Documentation Updates
- Updated API comments, the main README, and the spec documentation to reflect the new default declaration semantics
- Updated the second README example to explicitly demonstrate the transient-queue opt-in pattern (`durable: false, exclusive: true, autoDelete: true`)
- Updated `CHANGELOG.md` to document the behavior change

### Backward Compatibility
**Breaking change**: Re-declaring existing queues/exchanges with the new defaults may fail if the prior entities were created with different durability/auto-delete settings (users should delete and recreate entities or explicitly set properties).

### Follow-up Notes from Review
- Three new tests may leak resources (`verifyClient` not consistently closed, and `newClient` may remain open on early failure).
- `CHANGELOG.md` section ordering appears inconsistent with the recommended Keep a Changelog format.
- The exchange `autoDelete` fallback correction was made, but it is not explicitly called out in the `CHANGELOG`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->